### PR TITLE
M1: data layer + CLI (info, dump-inline)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.11", "3.12"]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,26 @@
+name: tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ["3.10", "3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install
+        run: pip install -e ".[dev]"
+      - name: Lint
+        run: ruff check .
+      - name: Test
+        run: pytest

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,62 @@
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# Virtual envs
+.venv/
+venv/
+ENV/
+env/
+
+# Test / coverage
+.pytest_cache/
+.coverage
+.coverage.*
+htmlcov/
+.tox/
+.nox/
+coverage.xml
+*.cover
+.cache/
+
+# mypy / ruff
+.mypy_cache/
+.ruff_cache/
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Project
+scratch.py
+scratch/
+tests/data/*.mdio/
+tests/data/*.segy
+*.png
+/demo.mdio/

--- a/M1-PLAN.md
+++ b/M1-PLAN.md
@@ -1,0 +1,537 @@
+# M1 — "The data opens"
+
+**Milestone 1 of the eggseis development roadmap. See `ROADMAP.md` for the full plan and the milestones that follow.**
+
+---
+
+## Goal
+
+Build a CLI that opens an MDIO survey, prints geometry, reads an inline, and saves it as a PNG. No UI yet.
+
+The point of M1 is to **prove you can read seismic data through a clean abstraction.** Not to build a full data layer. Not to optimize. Not to handle every edge case. Just to read an MDIO survey, expose it through a `SeismicVolume` object, and prove the whole stack works end-to-end with a CLI.
+
+Stay disciplined about that scope and M1 is a couple of focused weekends. Let it sprawl into "build the perfect data layer" and it'll take six months.
+
+## Exit criteria
+
+You're done with M1 when this works:
+
+```bash
+$ eggseis info tests/data/sample.mdio
+Survey: F3 Netherlands (sample fragment)
+  Inline range: 100–200
+  Crossline range: 300–400
+  Samples: 462
+  Sample rate: 4 ms
+  Format: float32
+
+$ eggseis dump-inline tests/data/sample.mdio 150 --output inline_150.png
+Wrote inline_150.png (1024×462, 0.4 MB)
+```
+
+And tests pass on Linux, macOS, and Windows in CI.
+
+---
+
+## Step 1: Project structure
+
+In your fresh `eggseis` repo, create this layout:
+
+```
+eggseis/
+├── README.md                 # already there
+├── LICENSE                   # already there
+├── ROADMAP.md                # already there
+├── .gitignore                # already there
+├── pyproject.toml            # NEW — replace any placeholder version
+├── src/
+│   └── eggseis/
+│       ├── __init__.py
+│       ├── data.py           # SeismicVolume abstraction
+│       ├── backends/
+│       │   ├── __init__.py
+│       │   └── mdio.py       # MDIOBackend implementation
+│       └── cli.py            # CLI entry point
+├── tests/
+│   ├── __init__.py
+│   ├── conftest.py           # pytest fixtures
+│   ├── test_data.py
+│   ├── test_mdio_backend.py
+│   └── data/                 # small test surveys (gitignored if large)
+└── .github/
+    └── workflows/
+        └── tests.yml         # CI on Linux/macOS/Windows
+```
+
+The `src/` layout (vs. having `eggseis/` at the top level) is the modern Python convention and prevents a class of import bugs. Use it.
+
+## Step 2: Set up the Python environment
+
+Pick a dev environment approach. Three reasonable options:
+
+- **Conda** — matches what eggseis will distribute as. Most consistent with the long-term plan. Recommended.
+- **venv + pip** — simpler if you already have Python installed.
+- **uv** — newer, much faster, increasingly popular.
+
+For conda:
+
+```bash
+conda create -n eggseis python=3.12 -c conda-forge
+conda activate eggseis
+conda install -c conda-forge mdio numpy pytest typer rich pillow
+pip install -e ".[dev]"
+```
+
+The `-e ".[dev]"` installs your package in "editable" mode — changes to your source code take effect immediately without reinstalling. This is the only way to develop a Python package sanely.
+
+## Step 3: pyproject.toml
+
+This is the source of truth for dependencies, version, and entry points.
+
+```toml
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "eggseis"
+version = "0.1.0.dev0"
+description = "An open-source desktop application for viewing and analyzing seismic data, with a Python plugin system."
+readme = "README.md"
+requires-python = ">=3.10"
+license = "Apache-2.0"
+license-files = ["LICENSE"]
+authors = [{ name = "Eric [Surname]", email = "your-email@example.com" }]
+keywords = ["seismic", "geoscience", "geophysics", "interpretation", "segy", "mdio"]
+classifiers = [
+    "Development Status :: 2 - Pre-Alpha",
+    "Intended Audience :: Science/Research",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Scientific/Engineering",
+    "Topic :: Scientific/Engineering :: Visualization",
+]
+
+dependencies = [
+    "numpy>=1.24",
+    "mdio>=0.8",
+    "typer>=0.12",
+    "rich>=13.0",
+    "pillow>=10.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0",
+    "pytest-cov>=5.0",
+    "ruff>=0.6",
+    "mypy>=1.10",
+]
+
+[project.scripts]
+eggseis = "eggseis.cli:app"
+
+[project.urls]
+Homepage = "https://github.com/eggseis/eggseis"
+Repository = "https://github.com/eggseis/eggseis"
+Issues = "https://github.com/eggseis/eggseis/issues"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/eggseis"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py310"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "N", "W", "UP", "B", "RUF"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "-v --strict-markers"
+```
+
+`version = "0.1.0.dev0"` — the `.dev0` suffix marks this as pre-release, appropriate for M1 work and won't conflict with your placeholder `0.0.2`.
+
+## Step 4: data.py — the SeismicVolume abstraction
+
+This is the heart of M1. The `SeismicVolume` is the stable public API everything upstream depends on. Get it right and you build for years on top of it.
+
+```python
+# src/eggseis/data.py
+"""Domain model for seismic data."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol, runtime_checkable
+
+import numpy as np
+
+
+@dataclass(frozen=True)
+class SurveyGeometry:
+    """Geometric description of a 3D seismic survey."""
+
+    inline_min: int
+    inline_max: int
+    inline_step: int
+    xline_min: int
+    xline_max: int
+    xline_step: int
+    n_samples: int
+    sample_rate_ms: float  # time sample interval in ms
+
+    @property
+    def n_inlines(self) -> int:
+        return (self.inline_max - self.inline_min) // self.inline_step + 1
+
+    @property
+    def n_xlines(self) -> int:
+        return (self.xline_max - self.xline_min) // self.xline_step + 1
+
+    @property
+    def shape(self) -> tuple[int, int, int]:
+        """(n_inlines, n_xlines, n_samples)"""
+        return (self.n_inlines, self.n_xlines, self.n_samples)
+
+    @property
+    def time_max_ms(self) -> float:
+        return (self.n_samples - 1) * self.sample_rate_ms
+
+
+@runtime_checkable
+class SeismicBackend(Protocol):
+    """Storage backend interface — what every backend must implement."""
+
+    @property
+    def geometry(self) -> SurveyGeometry: ...
+
+    @property
+    def dtype(self) -> np.dtype: ...
+
+    def read_inline(self, inline: int) -> np.ndarray: ...
+    def read_xline(self, xline: int) -> np.ndarray: ...
+    def read_timeslice(self, sample_index: int) -> np.ndarray: ...
+    def read_trace(self, inline: int, xline: int) -> np.ndarray: ...
+
+
+class SeismicVolume:
+    """The stable public abstraction for a 3D seismic volume.
+
+    Plugins, viewers, and CLI commands talk to this — never to backends
+    directly. Swapping the backend (MDIO, OpenVDS, TileDB) leaves the
+    upstream code untouched.
+    """
+
+    def __init__(self, backend: SeismicBackend, name: str = "unnamed"):
+        self._backend = backend
+        self.name = name
+
+    @property
+    def geometry(self) -> SurveyGeometry:
+        return self._backend.geometry
+
+    @property
+    def shape(self) -> tuple[int, int, int]:
+        return self.geometry.shape
+
+    @property
+    def dtype(self) -> np.dtype:
+        return self._backend.dtype
+
+    def read_inline(self, inline: int) -> np.ndarray:
+        """Read a single inline as shape (n_xlines, n_samples)."""
+        return self._backend.read_inline(inline)
+
+    def read_xline(self, xline: int) -> np.ndarray:
+        """Read a single crossline as shape (n_inlines, n_samples)."""
+        return self._backend.read_xline(xline)
+
+    def read_timeslice(self, sample_index: int) -> np.ndarray:
+        """Read a single time slice as shape (n_inlines, n_xlines)."""
+        return self._backend.read_timeslice(sample_index)
+
+    def read_trace(self, inline: int, xline: int) -> np.ndarray:
+        """Read a single trace as shape (n_samples,)."""
+        return self._backend.read_trace(inline, xline)
+
+    def __repr__(self) -> str:
+        g = self.geometry
+        return (
+            f"SeismicVolume(name={self.name!r}, "
+            f"shape={g.shape}, dtype={self.dtype}, "
+            f"sample_rate={g.sample_rate_ms}ms)"
+        )
+```
+
+**Two design notes worth internalizing:**
+
+The `Protocol` for `SeismicBackend` is doing real work — it's a structural contract. Anything with those four read methods and the geometry/dtype properties counts as a backend, no inheritance required. Swapping in a synthetic backend for testing or a different storage format requires zero ceremony.
+
+`SurveyGeometry` is a frozen dataclass on purpose. It's hashable, immutable, and makes a clean cache key once you get to M4. Frozen-by-default is the right discipline for value objects.
+
+## Step 5: backends/mdio.py — the MDIO backend
+
+The only backend in M1. Probably 50–80 lines depending on edge cases.
+
+**This sketch is approximate.** Verify the actual MDIO API before implementing — the TGS team has been actively iterating. Consult https://mdio-python.readthedocs.io for current method names and access patterns.
+
+```python
+# src/eggseis/backends/mdio.py
+"""MDIO storage backend."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+from mdio import MDIOReader  # confirm exact import path
+
+from eggseis.data import SurveyGeometry
+
+
+class MDIOBackend:
+    """Read 3D seismic from an MDIO store."""
+
+    def __init__(self, path: str | Path):
+        self.path = Path(path)
+        self._reader = MDIOReader(str(self.path))
+        self._geometry = self._build_geometry()
+
+    def _build_geometry(self) -> SurveyGeometry:
+        # Fill in based on MDIO's actual API
+        # — typically reading from self._reader.grid or similar
+        ...
+
+    @property
+    def geometry(self) -> SurveyGeometry:
+        return self._geometry
+
+    @property
+    def dtype(self) -> np.dtype:
+        return self._reader.stats["sample_format"]  # check actual API
+
+    def read_inline(self, inline: int) -> np.ndarray:
+        idx = (inline - self._geometry.inline_min) // self._geometry.inline_step
+        return self._reader[idx, :, :]
+
+    def read_xline(self, xline: int) -> np.ndarray:
+        idx = (xline - self._geometry.xline_min) // self._geometry.xline_step
+        return self._reader[:, idx, :]
+
+    def read_timeslice(self, sample_index: int) -> np.ndarray:
+        return self._reader[:, :, sample_index]
+
+    def read_trace(self, inline: int, xline: int) -> np.ndarray:
+        il = (inline - self._geometry.inline_min) // self._geometry.inline_step
+        xl = (xline - self._geometry.xline_min) // self._geometry.xline_step
+        return self._reader[il, xl, :]
+```
+
+**Pragmatic approach:** install mdio, point it at a sample dataset, get a NumPy array out of it, then refactor the working code into the structure above. Don't write the abstraction first and discover it doesn't fit — write the spike, then refactor.
+
+## Step 6: cli.py — the command-line interface
+
+```python
+# src/eggseis/cli.py
+"""Command-line interface for eggseis."""
+
+from pathlib import Path
+
+import numpy as np
+import typer
+from rich.console import Console
+from rich.table import Table
+
+from eggseis.backends.mdio import MDIOBackend
+from eggseis.data import SeismicVolume
+
+app = typer.Typer(help="eggseis — open-source seismic interpretation")
+console = Console()
+
+
+@app.command()
+def info(survey: Path = typer.Argument(..., help="Path to MDIO survey")) -> None:
+    """Show summary information about a seismic survey."""
+    backend = MDIOBackend(survey)
+    volume = SeismicVolume(backend, name=survey.stem)
+    g = volume.geometry
+
+    table = Table(title=f"Survey: {volume.name}", show_header=False)
+    table.add_column("Property", style="cyan")
+    table.add_column("Value")
+    table.add_row("Inline range", f"{g.inline_min}–{g.inline_max} (step {g.inline_step})")
+    table.add_row("Xline range", f"{g.xline_min}–{g.xline_max} (step {g.xline_step})")
+    table.add_row("Samples", str(g.n_samples))
+    table.add_row("Sample rate", f"{g.sample_rate_ms} ms")
+    table.add_row("Time max", f"{g.time_max_ms:.1f} ms")
+    table.add_row("Shape", f"{g.shape}")
+    table.add_row("Dtype", str(volume.dtype))
+    console.print(table)
+
+
+@app.command("dump-inline")
+def dump_inline(
+    survey: Path = typer.Argument(..., help="Path to MDIO survey"),
+    inline: int = typer.Argument(..., help="Inline number"),
+    output: Path = typer.Option("inline.png", "--output", "-o", help="Output PNG path"),
+) -> None:
+    """Read an inline and save it as a PNG."""
+    from PIL import Image
+
+    backend = MDIOBackend(survey)
+    volume = SeismicVolume(backend, name=survey.stem)
+    data = volume.read_inline(inline)
+
+    # Normalize to 0-255 with a 1-99 percentile linear stretch
+    arr = data.T  # transpose so time is vertical
+    p_low, p_high = np.percentile(arr, [1, 99])
+    arr = np.clip((arr - p_low) / (p_high - p_low), 0, 1)
+    arr_u8 = (arr * 255).astype(np.uint8)
+
+    Image.fromarray(arr_u8).save(output)
+    console.print(f"[green]Wrote[/green] {output} ({arr.shape[1]}×{arr.shape[0]})")
+
+
+if __name__ == "__main__":
+    app()
+```
+
+Once `pyproject.toml` is in place and `pip install -e ".[dev]"` has run, the `eggseis` command is available globally in your env.
+
+## Step 7: Tests
+
+Tests are not optional, even at M1. They're how you'll know in M3 that a refactor didn't break anything.
+
+```python
+# tests/conftest.py
+"""Pytest fixtures shared across tests."""
+
+import pytest
+
+
+@pytest.fixture
+def sample_mdio_path(tmp_path):
+    """Path to a small synthetic MDIO survey for testing.
+
+    In M1, generate a tiny synthetic survey programmatically using MDIO's
+    writer, OR check in a small (<10 MB) test fixture. In later milestones
+    this can become a downloaded F3 fragment.
+    """
+    ...
+```
+
+```python
+# tests/test_data.py
+"""Tests for the SeismicVolume abstraction."""
+
+from eggseis.data import SurveyGeometry
+
+
+def test_geometry_shape():
+    g = SurveyGeometry(
+        inline_min=100, inline_max=199, inline_step=1,
+        xline_min=300, xline_max=399, xline_step=1,
+        n_samples=512, sample_rate_ms=4.0,
+    )
+    assert g.n_inlines == 100
+    assert g.n_xlines == 100
+    assert g.shape == (100, 100, 512)
+    assert g.time_max_ms == 511 * 4.0
+```
+
+Don't worry about test coverage in M1. Worry about **the smallest set of tests that would catch a real regression.** Geometry calculations, basic backend reads, CLI exit codes. That's enough.
+
+## Step 8: CI
+
+A minimal GitHub Actions workflow that runs tests on Linux, macOS, and Windows:
+
+```yaml
+# .github/workflows/tests.yml
+name: tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ["3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - run: pip install -e ".[dev]"
+      - run: pytest
+      - run: ruff check .
+```
+
+Drop this in and CI runs on every push. If it goes red, fix it before doing anything else — green main is a discipline that pays back tenfold once you have collaborators.
+
+---
+
+## Execution order
+
+In order, the smallest unit of progress that gets you started:
+
+1. **Create the directory structure.** `mkdir -p src/eggseis/backends tests/data .github/workflows`. Touch the `__init__.py` files.
+
+2. **Drop in the `pyproject.toml`** above. Edit name and email.
+
+3. **Set up your conda environment.** `conda create`, activate, `pip install -e ".[dev]"`. Confirm `eggseis --help` works (typer's auto-generated help with no commands yet — that's fine).
+
+4. **Find a sample MDIO file.** First real obstacle. MDIO's GitHub has examples; you may need to convert a small SEG-Y to MDIO using their CLI. The SEG Wiki F3 dataset is the standard test fixture in this space and is freely available. Even a tiny 50 MB fragment is plenty for M1.
+
+5. **Write a one-file spike** that just opens the MDIO and prints the shape. Throwaway code — get the API right before structuring it. Put it in a notebook or a `scratch.py` file outside the package.
+
+6. **Once the spike works, refactor it into `MDIOBackend`** following the structure above.
+
+7. **Wire up the CLI** so `eggseis info path/to/survey.mdio` runs.
+
+8. **Add the PNG dump command.** When `eggseis dump-inline survey.mdio 100 --output inline_100.png` produces a recognizable seismic image, **M1 is functionally complete.**
+
+9. **Write the tests.** Push to GitHub. Watch CI go green.
+
+Two focused weekends, maybe three. Don't let any single step block you for more than a few hours — if the MDIO API is fighting you, drop into the Software Underground `#mdio` Slack channel and ask.
+
+---
+
+## Tactical notes
+
+**The hardest part of M1 won't be the code — it'll be MDIO itself.** Their library has been iterating, and the docs sometimes lag. Budget time for:
+
+- Reading MDIO's actual current API
+- Asking in the Software Underground `#mdio` Slack channel if you hit a wall
+- Possibly converting a small SEG-Y to MDIO yourself using their tooling
+
+**Legitimate fallback for M1 only:** if MDIO blocks you for more than a few sessions, swap in a `segyio`-based backend that reads directly from a small SEG-Y file. Same `SeismicBackend` Protocol, different storage. This is exactly what the abstraction is for. Move to MDIO at the start of M2.
+
+**Spike before structure.** Don't write the abstraction layer first and discover MDIO doesn't fit it. Get a working call chain end to end (`mdio` → `numpy` → `Image.save`) in a single throwaway script, then refactor it into the layered structure. The abstraction emerges from working code; it doesn't precede it.
+
+**Commit often, with messages from you.** Let Claude Code write the code; you write the commit messages. Summarizing changes in your own words is how you stay in command of the codebase.
+
+**Push back when something feels off.** If Claude Code proposes an approach that contradicts a decision in `ROADMAP.md` (xarray as the data model, disk caching in M1, etc.), say no and point at the relevant section.
+
+---
+
+## When M1 is done
+
+A clean exit from M1 looks like:
+
+- `eggseis info` and `eggseis dump-inline` work on a real MDIO survey.
+- All tests pass on Linux, macOS, and Windows in CI.
+- The repo is pushed, the README is up to date, the `CHANGELOG.md` records "M1 complete."
+- You commit and tag `v0.1.0a1` (alpha 1) on GitHub. Don't push to PyPI yet.
+- Take a beat. Then start M2 — "The section appears."

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,324 @@
+# eggseis — Development Roadmap
+
+**Working document for the development of eggseis from pre-alpha through v1.0 public release.**
+
+This roadmap captures the milestone plan and the design decisions behind it. It is intended to be edited as the project evolves — milestones may slip, scope may shift, and that's expected. What stays fixed is the discipline of shipping a demonstrable result every ~6 weeks.
+
+---
+
+## The North Star
+
+A free, cross-platform desktop application for viewing and analyzing 3D seismic data, with a Python plugin system so simple that "write a new attribute" is a ten-line script.
+
+**Primary user:** an industry geoscientist who scripts a little Python.
+
+**Non-goals for v1.0:** anything that isn't necessary to deliver on the sentence above. The "Out of Scope" list is long and deliberate.
+
+---
+
+## Locked-in Design Decisions
+
+These were settled during the design phase. Revisit them only with strong cause.
+
+| Area | Decision |
+|---|---|
+| License | Apache 2.0 |
+| Name | eggseis (PyPI reserved, GitHub org TBD) |
+| Plugin language | Python only in v1.0 (C++/Rust via pybind11/PyO3 inside Python plugins) |
+| Plugin tier | Trace-local (Tier 1) only in v1.0; API designed to extend to windows (Tier 2) without breaking changes |
+| Plugin data model | NumPy arrays + context dict (lowest barrier for scripters) |
+| Vectorization | Per-trace by default; opt-in `vectorized=True` flag |
+| Storage backend | MDIO as the single backend; clean abstraction for future OpenVDS / TileDB |
+| Project format | Plain directory on disk, YAML manifest, human-readable |
+| Compute cache | In-memory LRU only in v1.0; disk cache deferred to v1.1 |
+| UI toolkit | PySide6 (Qt) |
+| Section viewer | pyqtgraph |
+| Volume viewer | PyVista + VTK; three slicing planes default, full volume render opt-in |
+| Crossplot | pyqtgraph + datashader (auto-switch above ~500K points) |
+| Parameter UI | Pydantic schemas + magicgui widgets |
+| Distribution | Micromamba-bundled conda-forge environment; signed installers per platform |
+| Governance | BDFL (you) until phase 2 (~5 contributors); plan to evolve |
+
+---
+
+## Milestone Plan
+
+Each milestone ends in something demonstrable. Estimates assume part-time evening/weekend effort; full-time is roughly 2x faster.
+
+### M1 — "The data opens" *(weeks 1–4)*
+
+**Deliverable:** A CLI that opens an MDIO survey, prints geometry, reads an inline, and saves it as a PNG. No UI yet.
+
+**What gets built:**
+- `pyproject.toml` and project skeleton (already done — placeholder is on PyPI).
+- `eggseis.data.SeismicVolume` — the stable public abstraction. Properties: `geometry`, `shape`, `dtype`, `headers`. Methods: `read_inline()`, `read_xline()`, `read_timeslice()`, `read_trace()`, `read_traces()`, `read_window()`.
+- `eggseis.backends.mdio.MDIOBackend` — the first (and for v1.0, only) backend.
+- `eggseis.cli` — Typer or Click-based CLI with `eggseis info <survey>` and `eggseis dump-inline <survey> <inline_number>` commands.
+- A test fixture that downloads a small real MDIO survey (F3 Netherlands fragment, or generate synthetic).
+- CI on Linux/macOS/Windows running `pytest`.
+
+**Exit criteria:**
+- `eggseis info path/to/survey.mdio` prints inline range, xline range, sample rate, and basic stats.
+- `eggseis dump-inline path/to/survey.mdio 1000 --output inline_1000.png` produces a PNG that visibly shows the seismic.
+- Tests pass on all three platforms in CI.
+
+**Why this matters:** the data layer is the foundation everything else rests on. Get it right here and you can build for a year on top of it without revisiting.
+
+---
+
+### M2 — "The section appears" *(weeks 5–8)*
+
+**Deliverable:** A Qt application that opens a project, shows a list of surveys, and displays an inline in a pyqtgraph viewer with pan/zoom, colormap, and slice navigation.
+
+**What gets built:**
+- `eggseis.app` — main Qt application entry point.
+- Project tree widget showing surveys, horizons (empty for now), wells (empty for now).
+- Section viewer widget: pyqtgraph `ImageItem`, axis labels, crosshair readout, configurable colormap.
+- Slice navigation: keyboard shortcuts and a spinbox to step through inlines/xlines/timeslices.
+- Project loading: open a directory, parse `project.yaml`, populate the tree.
+- Basic menu structure (File, View, Help).
+
+**Exit criteria:**
+- Launch the app, open a sample project, double-click a survey, see the section viewer.
+- Pan, zoom, scroll through inlines, switch to xline view, switch to timeslice view — all responsive.
+- Colormap can be changed from a menu.
+
+**Why this matters:** this is the first moment the project has a face. You can demo it to a friend.
+
+---
+
+### M3 — "The plugin runs" *(weeks 9–14)*
+
+**Deliverable:** A decorator-based plugin API. Drop a `my_bandpass.py` in a folder; it appears in the attribute menu; selecting it applies to the visible section. Parameters auto-generate a dialog.
+
+**What gets built:**
+- `eggseis.plugin` module — `@trace_attribute` decorator, `Param` class.
+- Pydantic-based parameter schema — type, default, range, units, label, validators.
+- magicgui-based parameter widgets — automatic Qt UI from the parameter declarations.
+- Plugin discovery: scan `~/.eggseis/plugins/` and entry points, register decorated functions.
+- Plugin execution path: when an attribute is selected, run it on the visible section traces and paint result.
+- Five built-in plugins as public files (envelope, instantaneous phase, instantaneous frequency, RMS amplitude, Ormsby bandpass).
+- "New Plugin" template wizard — File → New Plugin → opens an editor with a working skeleton.
+
+**Exit criteria:**
+- Author a new plugin in a separate file, drop it in the plugins folder, restart, see it in the menu.
+- Selecting the plugin applies it to the section. Changing parameters in the dialog re-runs and updates.
+- A second person (a friend, colleague, anyone) can write a working plugin in under 30 minutes given only the docs. **If they can't, the API isn't right yet — fix it before moving on.**
+
+**Why this matters:** this is the wedge. The moment a non-you person can write a plugin and see it run is the moment the project has external value.
+
+---
+
+### M4 — "The compute feels good" *(weeks 15–20)*
+
+**Deliverable:** The compute engine — worker threads, debounce, cancellation, in-memory cache, progressive tile delivery. Sliders update the section live; pan-and-return is instant.
+
+**What gets built:**
+- `eggseis.compute.JobOrchestrator` — `QThreadPool`-based worker scheduling.
+- Debounce: 150ms timer that resets on each parameter change, fires once on quiet.
+- Cancellation: cooperative tokens checked between trace batches; in-flight jobs canceled when superseded.
+- Tile-level prioritization: viewport center first, then edges, then off-screen prefetch.
+- Progressive delivery: workers emit results in batches every ~50ms, viewer paints as they arrive.
+- In-memory LRU cache keyed by `(plugin_id, plugin_version, params_hash, slice_kind, slice_index, survey_version)`. Default ~500 MB.
+- `vectorized=True` opt-in path: plugin receives a 2D batch, function called once per chunk instead of once per trace.
+- Determinism flag (`deterministic=True` default) controlling cache eligibility.
+
+**Exit criteria:**
+- Drag a parameter slider on a slow attribute; UI stays responsive throughout; intermediate updates don't accumulate.
+- Pan back to a previously-computed view; result appears in <50ms (cache hit).
+- Run a vectorized plugin on a 1000×1500 section; total compute time under 1 second for typical SciPy operations.
+
+**Why this matters:** this is when the product stops feeling like a prototype and starts feeling like software. Biggest perceived-quality leap in the whole roadmap.
+
+---
+
+### M5 — "Horizons and wells" *(weeks 21–26)*
+
+**Deliverable:** Import and display horizons and wells on the section viewer. Project save/load round-trips correctly.
+
+**What gets built:**
+- Horizon importers: OpendTect ASCII, IHS grid, XYZ CSV.
+- `eggseis.data.Horizon` abstraction — gridded surface stored as Zarr 2D array inside the survey container, with JSON sidecar for non-gridded attributes.
+- Horizon overlay on section viewer: polyline intersected with the current slice, color-configurable.
+- Well importers: LAS 2.0/3.0 via `lasio`, XYZ deviation surveys.
+- `eggseis.data.Well` abstraction — HDF5 per well, log curves, deviation, markers.
+- Well overlay on section viewer: deviated path traversing the section, log curves alongside.
+- Header editor for surveys (display + correct trace header byte locations).
+- Project save: write `project.yaml`, persist tree state, viewer state, currently-loaded plugins.
+- Project load: round-trip the above without surprises.
+
+**Exit criteria:**
+- Import a horizon file, see it overlaid on the section in real time as you scroll inlines.
+- Import a deviated well with logs, see it appear on intersecting sections with curves.
+- Save the project, close the app, reopen — everything is exactly where you left it.
+
+**Why this matters:** product becomes useful for real work, not just a demo. You can interpret with it (in a limited way) starting here.
+
+---
+
+### M6 — "The volume" *(weeks 27–32)*
+
+**Deliverable:** PyVista volume viewer with three slicing planes, bounding box, horizon surfaces, well paths. Linked with the section viewer.
+
+**What gets built:**
+- `eggseis.viewers.volume` — PyVista `QtInteractor` widget embedded in the main window.
+- Three orthogonal slicing planes (`vtkImagePlaneWidget`-style), draggable, with the rest of the cube clipped.
+- Bounding box display showing the survey extent.
+- Horizon surfaces: render imported horizons as 3D meshes with configurable shading.
+- Well paths: render deviation surveys as polylines in the 3D scene.
+- Linked cursor: hovering in the section viewer moves the crosshair in the volume viewer at the same coordinate, and vice versa.
+- Camera controls: orbit, pan, zoom. Reset view, save/restore named camera positions.
+- Full volume rendering as an opt-in mode (probably with downsampled overview, full-res on idle — keep it simple in v1.0).
+
+**Exit criteria:**
+- Open a survey, switch to the volume viewer, see three planes plus bounding box.
+- Drag a slicing plane; corresponding section viewer (if open) moves to the matching slice.
+- Toggle horizons on/off; meshes appear/disappear correctly.
+- Performance feels fluid on a typical mid-sized survey (~5–20 GB).
+
+**Why this matters:** the "wow" moment for any demo. Also validates the architecture supports more than one viewer.
+
+---
+
+### M7 — "The crossplot" *(weeks 33–38)*
+
+**Deliverable:** pyqtgraph crossplot with header selection, lasso selection, linked highlighting in section and volume viewers. Datashader engages automatically above threshold.
+
+**What gets built:**
+- `eggseis.viewers.crossplot` — pyqtgraph-based scatter widget.
+- Header / attribute picker for X axis, Y axis, color.
+- Lasso and rectangle selection tools.
+- Datashader integration: above ~500K points, aggregate to a density image rather than rendering individual points. Switch is automatic and invisible to the user.
+- `eggseis.session.ViewerSession` — the central observable that coordinates all three viewers. Holds shared selection, cursor, active attribute, etc.
+- Linked selection: lasso a cluster in the crossplot, watch the corresponding samples highlight in section and volume viewers.
+- Density coloring for plain scatter mode.
+- Save/restore named crossplot views in the project.
+
+**Exit criteria:**
+- Open a project with a horizon attribute, plot it against another header, see the points.
+- Lasso a region; section viewer overlays the selected sample positions.
+- Crank up the dataset size; rendering remains responsive past 10M points (datashader path).
+
+**Why this matters:** rounds out the "three viewers" promise and proves the coordination layer works for richer interaction than just cursor linkage.
+
+---
+
+### M8 — "Alpha to real users" *(weeks 39–46)*
+
+**Deliverable:** Cross-platform installers, signed builds, auto-update check, first-run demo project. Ship a private alpha to 5–10 geoscientists you know. Fix the embarrassing things they find.
+
+**What gets built:**
+- Conda-forge environment specification: pinned dependency set, lockfile per platform.
+- Micromamba-based installer:
+  - Windows: NSIS installer, code-signed (Authenticode).
+  - macOS: `.dmg` with notarized app bundle. (Requires Apple Developer account, $99/year.)
+  - Linux: AppImage and a conda-forge package.
+- First-run flow: create default user plugin directory, drop demo project (F3 Netherlands fragment), open it.
+- Auto-update *check* (not auto-install) — on launch, ping a manifest, surface "new version available" if newer.
+- Crash reporting: structured error capture with plugin name, version, parameters, traceback.
+- "Send Feedback" link in the Help menu.
+- Documentation site (MkDocs Material): getting started tutorial, plugin author guide, API reference.
+- Private alpha distribution: invite 5–10 specific people, weekly check-ins, ruthless triage of feedback.
+
+**Exit criteria:**
+- Five geoscientists install the app on their own machines (Windows + macOS coverage minimum) without your help.
+- Each one runs through the demo project and writes at least one custom plugin.
+- You collect a list of at least 20 issues from them and fix the top 10 before M9.
+
+**Why this matters:** this is where you find out what you got wrong. You will have gotten something important wrong. Better to know at week 40 than week 80.
+
+---
+
+### M9 — "v1.0 public" *(weeks 47–52)*
+
+**Deliverable:** Public release. GitHub repo polished, docs published, announcement on Software Underground / LinkedIn / blog. Five solid built-in attributes. A small registry of community plugins (even if seeded with 2–3 you wrote yourself).
+
+**What gets built:**
+- README polished with screenshots and a 30-second demo GIF.
+- ROADMAP.md split out (a public version of this document).
+- CHANGELOG.md starting from v1.0.
+- CONTRIBUTING.md with the contributor flow (CLA setup, dev environment, "good first issues").
+- Code of Conduct (Software Underground's, or Contributor Covenant).
+- Plugin registry: a simple page on the docs site listing known community plugins with links to their PyPI / GitHub.
+- Three "Good First Issue" plugins published as separate PyPI packages: `eggseis-ssa`, `eggseis-spectral`, `eggseis-geometric` (or whatever feels right).
+- Announcement plan executed:
+  - Software Underground Slack `#eggseis` channel announcement.
+  - LinkedIn post (your network).
+  - Blog post #1 of a series.
+  - Conference abstract submitted (SEG, EAGE, or Transform — whichever timing aligns).
+- v1.0.0 tagged release on GitHub with full release notes.
+
+**Exit criteria:**
+- The release ships. Real strangers download it. Some of them file issues. Some of them submit PRs.
+- You've done at least one public talk or demo in the 30 days post-release.
+- Year 2 of the project starts with momentum, not a void.
+
+**Why this matters:** this is the goal.
+
+---
+
+## Out of Scope for v1.0
+
+These are not bugs in v1.0 — they are deliberately deferred. Each one is a real feature; none is necessary for the v1.0 promise.
+
+| Feature | Earliest target |
+|---|---|
+| Disk-backed compute cache | v1.1 |
+| SEG-Y export | v1.1 |
+| Window-based attributes (Tier 2) | v1.1 |
+| Volume-to-volume transforms (Tier 3) | v1.2 |
+| DLIS well import | v1.1 |
+| Cloud object storage UI (S3, GCS) | v1.2 |
+| Cross-domain plugins (horizon+seismic) | v1.2 |
+| Horizon auto-tracking | v2.0 |
+| Fault extraction | v2.0 |
+| Spectral decomposition (built-in) | v2.0 |
+| Prestack / gathers, 4D surveys | v2.0+ |
+| Petrel / OpenWorks data exchange | v2.0+ |
+| Manual interpretation tools (picking) | v2.0+ |
+| Geomodeling, inversion, simulation | Out of scope indefinitely |
+| Web/mobile deployments | Out of scope indefinitely |
+| ML/AI plugins (built-in) | Community-driven, out of core indefinitely |
+
+---
+
+## Risks to Watch
+
+These are the failure modes specific to a project like this:
+
+1. **Perfection trap.** Domain expertise + open-source = constant urge to polish before shipping. Resist. Imperfect-and-shipped beats perfect-and-vapor every time.
+2. **Audience drift.** Each "small" feature request from a different user persona is fine alone; collectively they destroy scope. Target user = "industry geoscientist who scripts a bit." Anyone else waits for v2.
+3. **Solo-founder burnout.** 2+ years of evening/weekend work needs sustainable habits: dogfood the tool on real work, celebrate milestones publicly, take real breaks without guilt.
+4. **One-company capture.** If a single sponsor becomes >50% of contributions, governance gets distorted. Diversify even when it costs short-term progress.
+5. **Maintenance debt.** Post-v1.0, budget 20% of ongoing time for pure maintenance (dependency bumps, Python releases, Qt updates). Projects that ignore this die in year 2 or 3.
+
+---
+
+## What "Done with M1" Looks Like
+
+To make the next concrete action obvious:
+
+```bash
+# Tonight or this weekend
+$ git clone https://github.com/eggseis/eggseis.git
+$ cd eggseis
+$ python -m venv .venv && source .venv/bin/activate
+$ pip install -e ".[dev]"
+$ pytest
+$ eggseis info tests/data/sample.mdio
+Survey: F3 Netherlands (sample fragment)
+  Inline range: 100–200
+  Crossline range: 300–400
+  Samples: 462
+  Sample rate: 4 ms
+  Format: float32
+
+$ eggseis dump-inline tests/data/sample.mdio 150 --output inline_150.png
+Wrote inline_150.png (1024×462, 0.4 MB)
+```
+
+That's M1 done. Everything else flows from there.
+
+---
+
+*This document is a living plan. Edit it as priorities shift — but be honest with yourself about why scope is changing each time you do.*

--- a/docs/design/m1-architecture.md
+++ b/docs/design/m1-architecture.md
@@ -1,0 +1,240 @@
+# M1 Architecture — Data Layer
+
+This document captures the class structure and runtime call paths of the M1 data layer. It complements [`M1-PLAN.md`](../../M1-PLAN.md), which describes the milestone scope.
+
+## Class diagram
+
+```mermaid
+classDiagram
+    class SurveyGeometry {
+      <<frozen dataclass>>
+      +inline_min: int
+      +inline_max: int
+      +inline_step: int
+      +xline_min: int
+      +xline_max: int
+      +xline_step: int
+      +n_samples: int
+      +sample_rate_ms: float
+      +n_inlines() int
+      +n_xlines() int
+      +shape() tuple
+      +time_max_ms() float
+    }
+
+    class SeismicBackend {
+      <<Protocol>>
+      +geometry: SurveyGeometry
+      +dtype: np.dtype
+      +read_inline(int) ndarray
+      +read_xline(int) ndarray
+      +read_timeslice(int) ndarray
+      +read_trace(int, int) ndarray
+    }
+
+    class SeismicVolume {
+      -_backend: SeismicBackend
+      +name: str
+      +geometry()
+      +dtype()
+      +shape()
+      +read_inline(int)
+      +read_xline(int)
+      +read_timeslice(int)
+      +read_trace(int, int)
+    }
+
+    class MDIOBackend {
+      -_ds: xarray.Dataset
+      -_var: xarray.DataArray
+      -_var_name: str
+      -_inline_dim: str
+      -_xline_dim: str
+      -_sample_dim: str
+      -_geometry: SurveyGeometry
+    }
+
+    class FakeBackend {
+      -_geometry: SurveyGeometry
+      -_cube: ndarray
+    }
+
+    SurveyGeometry <-- SeismicBackend : has
+    SurveyGeometry <-- SeismicVolume : has
+    SeismicBackend <|.. MDIOBackend : duck-types
+    SeismicBackend <|.. FakeBackend : duck-types
+    SeismicVolume o-- SeismicBackend : wraps
+```
+
+## Class structure (ASCII)
+
+```
+                              ┌─────────────────────────────────┐
+                              │  SurveyGeometry  (frozen dataclass)
+                              │  ─────────────────────────────────
+                              │  inline_min/max/step : int
+                              │  xline_min/max/step  : int
+                              │  n_samples           : int
+                              │  sample_rate_ms      : float
+                              │  + n_inlines  (prop)
+                              │  + n_xlines   (prop)
+                              │  + shape      (prop)
+                              │  + time_max_ms (prop)
+                              └─────────────────────────────────┘
+                                  ▲                       ▲
+                                  │ has-a                 │ has-a
+                                  │                       │
+                ┌─────────────────┴───┐     ┌─────────────┴─────────────┐
+                │  SeismicBackend     │     │  SeismicVolume            │
+                │  «Protocol»         │◀────┤  ─────────────────────────│
+                │  ─────────────────  │ has │  - _backend : SeismicBackend
+                │  + geometry: SG     │     │  + name     : str          │
+                │  + dtype:    dtype  │     │  + geometry : SG (delegated)
+                │  + read_inline()    │     │  + dtype    : dtype  (del.) │
+                │  + read_xline()     │     │  + shape    : tuple  (del.) │
+                │  + read_timeslice() │     │  + read_inline()    (del.) │
+                │  + read_trace()     │     │  + read_xline()     (del.) │
+                └─────────────────────┘     │  + read_timeslice() (del.) │
+                  ▲ structurally satisfies  │  + read_trace()     (del.) │
+                  │ (duck typing)           └────────────────────────────┘
+        ┌─────────┴─────────┐
+        │                   │
+┌───────┴────────┐   ┌──────┴──────────┐
+│  MDIOBackend   │   │  FakeBackend    │  (tests/conftest.py)
+│  ────────────  │   │  ─────────────  │
+│  - _ds         │   │  - _geometry    │
+│  - _var        │   │  - _cube (numpy)│
+│  - _var_name   │   │   in-memory     │
+│  - _inline_dim │   │   deterministic │
+│  - _xline_dim  │   │   (seed=42)     │
+│  - _sample_dim │   └─────────────────┘
+│  - _geometry   │
+└────────┬───────┘
+         │ uses (lazy)
+         ▼
+   xarray.Dataset
+   (mdio.open_mdio)
+         │ chunks fetched on .values
+         ▼
+   Zarr store on disk
+```
+
+## Runtime flow — `eggseis info <survey>`
+
+```
+┌─────────────────────────────┐
+│ Shell: eggseis info demo... │
+└──────────────┬──────────────┘
+               │ entry_point script (.venv/bin/eggseis)
+               ▼
+┌─────────────────────────────┐      pyproject.toml:
+│ eggseis.cli:app             │      [project.scripts]
+│ (typer.Typer)               │        eggseis = "eggseis.cli:app"
+└──────────────┬──────────────┘
+               │ dispatch by command name
+               ▼
+┌─────────────────────────────┐
+│ cli.info(survey)            │  src/eggseis/cli.py
+└──────────────┬──────────────┘
+               │ calls
+               ▼
+┌─────────────────────────────┐
+│ cli._open(survey)           │
+│   ↓                         │
+│ MDIOBackend(path)           │── ctor opens lazy Dataset
+│   ↓                         │   resolves dims + var name
+│ SeismicVolume(backend, ...) │── thin wrapper
+└──────────────┬──────────────┘
+               │ returns SeismicVolume
+               ▼
+┌─────────────────────────────┐
+│ volume.geometry             │── delegates to backend._geometry
+└──────────────┬──────────────┘
+               │ returns SurveyGeometry
+               ▼
+┌─────────────────────────────┐
+│ rich.Table.add_row(...)     │
+│ rich.Console.print(table)   │
+└──────────────┬──────────────┘
+               ▼
+        terminal output
+```
+
+## Runtime flow — `eggseis dump-inline <survey> <N>`
+
+```
+cli.dump_inline(survey, inline=130)
+  │
+  ├─► _open(survey) ──► MDIOBackend ──► open_mdio() lazy Dataset
+  │                                            │
+  ├─► volume.read_inline(130) ─────────────────┤
+  │                                            │
+  │     SeismicVolume.read_inline ────────────►│
+  │       │                                    │
+  │       └──► self._backend.read_inline(130) ─┤
+  │              │                             │
+  │              └──► self._var                │
+  │                    .sel({inline_dim:130})  │  ← lazy filter
+  │                    .transpose(xl, sample)  │  ← lazy reorder
+  │                    .values  ───────────────► fetches Zarr chunks
+  │                                                returns numpy ndarray
+  │                                                shape (n_xline, n_sample)
+  │  ◄──────────────────────────────────────────  
+  │
+  ├─► np.percentile + clip + scale  (numpy ops)
+  │
+  ├─► PIL.Image.fromarray(uint8)
+  │   .save("inline.png")
+  │
+  └─► rich.Console.print("Wrote ...")
+```
+
+## Test wiring
+
+```
+   pytest fixtures (tests/conftest.py)
+   ─────────────────────────────────
+   fake_backend  ──► FakeBackend()  ──┐
+                                      │ injected into
+                                      ▼
+                              test_volume_*
+                              (tests/test_data.py)
+                              passes Volume tests w/o I/O
+
+
+   sample_mdio_path (session) ──► _build_synthetic_mdio()
+        │                              │
+        │                              ├─► xarray.Dataset (in-memory)
+        │                              └─► mdio.to_mdio() ──► Zarr on disk
+        ▼
+   tests/test_mdio_backend.py
+        │
+        └─► MDIOBackend(sample_mdio_path)
+              │
+              └─► open_mdio() reads back
+              └─► assertions on geometry + slice shapes
+```
+
+## Key relationships
+
+1. **`SeismicVolume` wraps a `SeismicBackend`** — composition, not inheritance. The volume is a thin façade; all reads delegate to the backend. This is the seam where future viewers (section, volume, crossplot per ROADMAP M2/M6/M7) attach.
+
+2. **`SeismicBackend` is a `Protocol`** — Python's structural typing equivalent of an interface. `MDIOBackend` and `FakeBackend` don't declare implementation; they simply expose the right shape. `isinstance(b, SeismicBackend)` returns `True` at runtime via `@runtime_checkable`. New backends (OpenVDS, TileDB — see [ROADMAP.md](../../ROADMAP.md)) implement the same Protocol.
+
+3. **`SurveyGeometry` is the single source of geometry truth.** Owned by the backend, surfaced read-only by the volume. Frozen dataclass → hashable, immutable, future-friendly as a cache key when the M4 compute engine lands.
+
+4. **`MDIOBackend` owns all xarray internals.** `_ds`, `_var`, dim-name caches never leak out. Volume and CLI never touch xarray. Swapping the backend leaves the upstream code untouched — exactly what ROADMAP's "abstraction layer" decision was meant to deliver.
+
+5. **`FakeBackend` is the test seam.** Same structural shape, in-memory, deterministic (`seed=42`). Lets us test `SeismicVolume` without disk I/O. Why Protocol-not-inheritance pays off: zero ceremony to add this.
+
+## Where new code lands in this graph
+
+| Future feature | Goes here |
+|---|---|
+| New storage backend (OpenVDS, TileDB) | New class implementing `SeismicBackend` |
+| New attribute/plugin (M3) | Operates on `SeismicVolume.read_inline` etc. |
+| Section viewer (M2) | Consumer of `SeismicVolume` |
+| Volume / crossplot viewers (M6/M7) | Same — all hang off `SeismicVolume` |
+| Compute engine cache (M4) | Wraps the volume; key = `(plugin_id, params, slice_kind, idx, survey_version)` |
+
+The graph stays small for M1. The shape was chosen so each later milestone slots in without breaking the data layer.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "eggseis"
 version = "0.1.0.dev0"
 description = "An open-source desktop application for viewing and analyzing seismic data, with a Python plugin system."
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 license = "Apache-2.0"
 license-files = ["LICENSE"]
 authors = [{ name = "Eric Geordi", email = "laforge2001@gmail.com" }]
@@ -17,7 +17,6 @@ classifiers = [
     "Intended Audience :: Science/Research",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Topic :: Scientific/Engineering",
@@ -53,7 +52,7 @@ packages = ["src/eggseis"]
 
 [tool.ruff]
 line-length = 100
-target-version = "py310"
+target-version = "py311"
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "N", "W", "UP", "B", "RUF"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,67 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "eggseis"
+version = "0.1.0.dev0"
+description = "An open-source desktop application for viewing and analyzing seismic data, with a Python plugin system."
+readme = "README.md"
+requires-python = ">=3.10"
+license = "Apache-2.0"
+license-files = ["LICENSE"]
+authors = [{ name = "Eric Geordi", email = "laforge2001@gmail.com" }]
+keywords = ["seismic", "geoscience", "geophysics", "interpretation", "segy", "mdio"]
+classifiers = [
+    "Development Status :: 2 - Pre-Alpha",
+    "Intended Audience :: Science/Research",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Scientific/Engineering",
+    "Topic :: Scientific/Engineering :: Visualization",
+]
+
+dependencies = [
+    "numpy>=1.24",
+    "multidimio>=1.1",
+    "typer>=0.12",
+    "rich>=13.0",
+    "pillow>=10.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0",
+    "pytest-cov>=5.0",
+    "ruff>=0.6",
+    "mypy>=1.10",
+]
+
+[project.scripts]
+eggseis = "eggseis.cli:app"
+
+[project.urls]
+Homepage = "https://github.com/eggseis/eggseis"
+Repository = "https://github.com/eggseis/eggseis"
+Issues = "https://github.com/eggseis/eggseis/issues"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/eggseis"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py310"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "N", "W", "UP", "B", "RUF"]
+ignore = ["RUF001", "RUF002", "RUF003"]  # allow en-dash, ×, etc. in user-facing strings
+
+[tool.ruff.lint.per-file-ignores]
+"src/eggseis/cli.py" = ["B008"]  # typer.Argument/Option in defaults is idiomatic
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "-v --strict-markers"

--- a/src/eggseis/__init__.py
+++ b/src/eggseis/__init__.py
@@ -1,0 +1,3 @@
+"""eggseis — open-source seismic interpretation."""
+
+__version__ = "0.1.0.dev0"

--- a/src/eggseis/backends/__init__.py
+++ b/src/eggseis/backends/__init__.py
@@ -1,0 +1,1 @@
+"""Storage backends for seismic data."""

--- a/src/eggseis/backends/mdio.py
+++ b/src/eggseis/backends/mdio.py
@@ -1,0 +1,136 @@
+"""MDIO storage backend (mdio v1 / xarray-based)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+
+from eggseis.data import SurveyGeometry
+
+INLINE_DIM_CANDIDATES = ("inline",)
+XLINE_DIM_CANDIDATES = ("crossline", "xline")
+SAMPLE_DIM_CANDIDATES = ("time", "depth", "sample", "twt")
+
+
+class MDIOBackend:
+    """Read 3D seismic from an MDIO v1 store via xarray."""
+
+    def __init__(self, path: str | Path):
+        from mdio import open_mdio
+
+        self.path = Path(path)
+        self._ds = open_mdio(str(self.path))
+
+        self._var_name = self._resolve_data_variable()
+        self._var = self._ds[self._var_name]
+        self._inline_dim = self._resolve_dim(INLINE_DIM_CANDIDATES, "inline")
+        self._xline_dim = self._resolve_dim(XLINE_DIM_CANDIDATES, "crossline")
+        self._sample_dim = self._resolve_dim(SAMPLE_DIM_CANDIDATES, "time/depth")
+
+        self._geometry = self._build_geometry()
+
+    def _resolve_data_variable(self) -> str:
+        default = self._ds.attrs.get("defaultVariableName")
+        if default and default in self._ds.data_vars:
+            return default
+        candidates = [
+            name
+            for name, var in self._ds.data_vars.items()
+            if var.ndim == 3 and np.issubdtype(var.dtype, np.floating)
+        ]
+        if not candidates:
+            msg = f"No 3D floating-point data variable found in {self.path}"
+            raise ValueError(msg)
+        candidates.sort(key=lambda n: self._ds[n].size, reverse=True)
+        return candidates[0]
+
+    def _resolve_dim(self, candidates: tuple[str, ...], label: str) -> str:
+        for name in candidates:
+            if name in self._var.dims:
+                return name
+        msg = f"Could not find {label} dimension in {self._var.dims}; tried {candidates}"
+        raise ValueError(msg)
+
+    def _build_geometry(self) -> SurveyGeometry:
+        inline_min, inline_max, inline_step = _coord_range(
+            self._ds.coords[self._inline_dim].values
+        )
+        xline_min, xline_max, xline_step = _coord_range(
+            self._ds.coords[self._xline_dim].values
+        )
+        sample_coord = self._ds.coords[self._sample_dim]
+        return SurveyGeometry(
+            inline_min=inline_min,
+            inline_max=inline_max,
+            inline_step=inline_step,
+            xline_min=xline_min,
+            xline_max=xline_max,
+            xline_step=xline_step,
+            n_samples=int(sample_coord.size),
+            sample_rate_ms=_sample_rate_ms(sample_coord),
+        )
+
+    @property
+    def geometry(self) -> SurveyGeometry:
+        return self._geometry
+
+    @property
+    def dtype(self) -> np.dtype:
+        return self._var.dtype
+
+    def read_inline(self, inline: int) -> np.ndarray:
+        return (
+            self._var.sel({self._inline_dim: inline})
+            .transpose(self._xline_dim, self._sample_dim)
+            .values
+        )
+
+    def read_xline(self, xline: int) -> np.ndarray:
+        return (
+            self._var.sel({self._xline_dim: xline})
+            .transpose(self._inline_dim, self._sample_dim)
+            .values
+        )
+
+    def read_timeslice(self, sample_index: int) -> np.ndarray:
+        return (
+            self._var.isel({self._sample_dim: sample_index})
+            .transpose(self._inline_dim, self._xline_dim)
+            .values
+        )
+
+    def read_trace(self, inline: int, xline: int) -> np.ndarray:
+        return (
+            self._var.sel({self._inline_dim: inline, self._xline_dim: xline}).values
+        )
+
+
+def _coord_range(coord: np.ndarray) -> tuple[int, int, int]:
+    if coord.size == 0:
+        msg = "Empty coordinate array"
+        raise ValueError(msg)
+    if coord.size == 1:
+        v = int(coord[0])
+        return v, v, 1
+    diffs = np.diff(coord)
+    if not np.all(diffs == diffs[0]):
+        msg = f"Non-uniform coordinate spacing: diffs={np.unique(diffs)}"
+        raise ValueError(msg)
+    step = int(diffs[0])
+    if step == 0:
+        msg = "Coordinate has zero step"
+        raise ValueError(msg)
+    return int(coord[0]), int(coord[-1]), step
+
+
+def _sample_rate_ms(coord) -> float:
+    """Sample rate in ms, derived from coord step + units attr."""
+    values = coord.values
+    if values.size < 2:
+        return 0.0
+    step = float(values[1] - values[0])
+    units = (coord.attrs.get("units") or "").lower()
+    if units in ("s", "sec", "second", "seconds"):
+        return step * 1000.0
+    return step

--- a/src/eggseis/cli.py
+++ b/src/eggseis/cli.py
@@ -1,0 +1,71 @@
+"""Command-line interface for eggseis."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import typer
+from rich.console import Console
+from rich.table import Table
+
+from eggseis.backends.mdio import MDIOBackend
+from eggseis.data import SeismicVolume
+
+app = typer.Typer(help="eggseis — open-source seismic interpretation", no_args_is_help=True)
+console = Console()
+
+
+def _open(survey: Path) -> SeismicVolume:
+    backend = MDIOBackend(survey)
+    return SeismicVolume(backend, name=survey.stem)
+
+
+@app.command()
+def info(survey: Path = typer.Argument(..., help="Path to MDIO survey")) -> None:
+    """Show summary information about a seismic survey."""
+    volume = _open(survey)
+    g = volume.geometry
+
+    table = Table(title=f"Survey: {volume.name}", show_header=False)
+    table.add_column("Property", style="cyan")
+    table.add_column("Value")
+    table.add_row("Inline range", f"{g.inline_min}–{g.inline_max} (step {g.inline_step})")
+    table.add_row("Xline range", f"{g.xline_min}–{g.xline_max} (step {g.xline_step})")
+    table.add_row("Samples", str(g.n_samples))
+    table.add_row("Sample rate", f"{g.sample_rate_ms} ms")
+    table.add_row("Time max", f"{g.time_max_ms:.1f} ms")
+    table.add_row("Shape", f"{g.shape}")
+    table.add_row("Dtype", str(volume.dtype))
+    console.print(table)
+
+
+@app.command("dump-inline")
+def dump_inline(
+    survey: Path = typer.Argument(..., help="Path to MDIO survey"),
+    inline: int = typer.Argument(..., help="Inline number"),
+    output: Path = typer.Option("inline.png", "--output", "-o", help="Output PNG path"),
+) -> None:
+    """Read an inline and save it as a PNG (1–99 percentile linear stretch)."""
+    from PIL import Image
+
+    volume = _open(survey)
+    data = volume.read_inline(inline)
+
+    arr = data.T  # transpose so time is vertical
+    p_low, p_high = np.percentile(arr, [1, 99])
+    if p_high == p_low:
+        normalized = np.zeros_like(arr, dtype=np.float32)
+    else:
+        normalized = np.clip((arr - p_low) / (p_high - p_low), 0, 1)
+    arr_u8 = (normalized * 255).astype(np.uint8)
+
+    Image.fromarray(arr_u8).save(output)
+    size_mb = output.stat().st_size / (1024 * 1024)
+    console.print(
+        f"[green]Wrote[/green] {output} ({arr.shape[1]}×{arr.shape[0]}, {size_mb:.1f} MB)"
+    )
+
+
+if __name__ == "__main__":
+    app()

--- a/src/eggseis/data.py
+++ b/src/eggseis/data.py
@@ -1,0 +1,104 @@
+"""Domain model for seismic data."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol, runtime_checkable
+
+import numpy as np
+
+
+@dataclass(frozen=True)
+class SurveyGeometry:
+    """Geometric description of a 3D seismic survey."""
+
+    inline_min: int
+    inline_max: int
+    inline_step: int
+    xline_min: int
+    xline_max: int
+    xline_step: int
+    n_samples: int
+    sample_rate_ms: float
+
+    @property
+    def n_inlines(self) -> int:
+        return (self.inline_max - self.inline_min) // self.inline_step + 1
+
+    @property
+    def n_xlines(self) -> int:
+        return (self.xline_max - self.xline_min) // self.xline_step + 1
+
+    @property
+    def shape(self) -> tuple[int, int, int]:
+        """(n_inlines, n_xlines, n_samples)."""
+        return (self.n_inlines, self.n_xlines, self.n_samples)
+
+    @property
+    def time_max_ms(self) -> float:
+        return (self.n_samples - 1) * self.sample_rate_ms
+
+
+@runtime_checkable
+class SeismicBackend(Protocol):
+    """Storage backend interface — what every backend must implement."""
+
+    @property
+    def geometry(self) -> SurveyGeometry: ...
+
+    @property
+    def dtype(self) -> np.dtype: ...
+
+    def read_inline(self, inline: int) -> np.ndarray: ...
+    def read_xline(self, xline: int) -> np.ndarray: ...
+    def read_timeslice(self, sample_index: int) -> np.ndarray: ...
+    def read_trace(self, inline: int, xline: int) -> np.ndarray: ...
+
+
+class SeismicVolume:
+    """Stable public abstraction for a 3D seismic volume.
+
+    Plugins, viewers, and CLI commands talk to this — never to backends
+    directly. Swapping the backend (MDIO, OpenVDS, TileDB) leaves the
+    upstream code untouched.
+    """
+
+    def __init__(self, backend: SeismicBackend, name: str = "unnamed"):
+        self._backend = backend
+        self.name = name
+
+    @property
+    def geometry(self) -> SurveyGeometry:
+        return self._backend.geometry
+
+    @property
+    def shape(self) -> tuple[int, int, int]:
+        return self.geometry.shape
+
+    @property
+    def dtype(self) -> np.dtype:
+        return self._backend.dtype
+
+    def read_inline(self, inline: int) -> np.ndarray:
+        """Read single inline as shape (n_xlines, n_samples)."""
+        return self._backend.read_inline(inline)
+
+    def read_xline(self, xline: int) -> np.ndarray:
+        """Read single crossline as shape (n_inlines, n_samples)."""
+        return self._backend.read_xline(xline)
+
+    def read_timeslice(self, sample_index: int) -> np.ndarray:
+        """Read single time slice as shape (n_inlines, n_xlines)."""
+        return self._backend.read_timeslice(sample_index)
+
+    def read_trace(self, inline: int, xline: int) -> np.ndarray:
+        """Read single trace as shape (n_samples,)."""
+        return self._backend.read_trace(inline, xline)
+
+    def __repr__(self) -> str:
+        g = self.geometry
+        return (
+            f"SeismicVolume(name={self.name!r}, "
+            f"shape={g.shape}, dtype={self.dtype}, "
+            f"sample_rate={g.sample_rate_ms}ms)"
+        )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,98 @@
+"""Pytest fixtures shared across tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from eggseis.data import SurveyGeometry
+
+
+class FakeBackend:
+    """In-memory backend satisfying the SeismicBackend Protocol.
+
+    Used to test SeismicVolume + Protocol contract without needing a real
+    MDIO fixture. Geometry is fixed and reads return deterministic synthetic
+    data so assertions can check exact values.
+    """
+
+    def __init__(
+        self,
+        inline_min: int = 100,
+        inline_max: int = 109,
+        xline_min: int = 300,
+        xline_max: int = 314,
+        n_samples: int = 32,
+        sample_rate_ms: float = 4.0,
+    ):
+        self._geometry = SurveyGeometry(
+            inline_min=inline_min,
+            inline_max=inline_max,
+            inline_step=1,
+            xline_min=xline_min,
+            xline_max=xline_max,
+            xline_step=1,
+            n_samples=n_samples,
+            sample_rate_ms=sample_rate_ms,
+        )
+        rng = np.random.default_rng(seed=42)
+        self._cube = rng.standard_normal(self._geometry.shape).astype(np.float32)
+
+    @property
+    def geometry(self) -> SurveyGeometry:
+        return self._geometry
+
+    @property
+    def dtype(self) -> np.dtype:
+        return self._cube.dtype
+
+    def read_inline(self, inline: int) -> np.ndarray:
+        i = (inline - self._geometry.inline_min) // self._geometry.inline_step
+        return self._cube[i, :, :]
+
+    def read_xline(self, xline: int) -> np.ndarray:
+        x = (xline - self._geometry.xline_min) // self._geometry.xline_step
+        return self._cube[:, x, :]
+
+    def read_timeslice(self, sample_index: int) -> np.ndarray:
+        return self._cube[:, :, sample_index]
+
+    def read_trace(self, inline: int, xline: int) -> np.ndarray:
+        i = (inline - self._geometry.inline_min) // self._geometry.inline_step
+        x = (xline - self._geometry.xline_min) // self._geometry.xline_step
+        return self._cube[i, x, :]
+
+
+@pytest.fixture
+def fake_backend() -> FakeBackend:
+    return FakeBackend()
+
+
+def _build_synthetic_mdio(path: Path) -> None:
+    import xarray as xr
+    from mdio import to_mdio
+
+    n_il, n_xl, n_t = 8, 6, 32
+    inline = np.arange(100, 100 + n_il, dtype=np.int32)
+    crossline = np.arange(300, 300 + n_xl, dtype=np.int32)
+    time = np.arange(n_t, dtype=np.float32) * 4.0
+
+    rng = np.random.default_rng(seed=1)
+    data = rng.standard_normal((n_il, n_xl, n_t)).astype(np.float32)
+
+    ds = xr.Dataset(
+        data_vars={"amplitude": (("inline", "crossline", "time"), data)},
+        coords={"inline": inline, "crossline": crossline, "time": time},
+        attrs={"defaultVariableName": "amplitude"},
+    )
+    ds.coords["time"].attrs["units"] = "ms"
+    to_mdio(ds, str(path), mode="w")
+
+
+@pytest.fixture(scope="session")
+def sample_mdio_path(tmp_path_factory) -> Path:
+    path = tmp_path_factory.mktemp("mdio") / "synth.mdio"
+    _build_synthetic_mdio(path)
+    return path

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,0 +1,69 @@
+"""Tests for the SeismicVolume / SurveyGeometry abstractions."""
+
+from __future__ import annotations
+
+import dataclasses
+
+import numpy as np
+import pytest
+
+from eggseis.data import SeismicBackend, SeismicVolume, SurveyGeometry
+
+
+def test_geometry_shape_and_counts() -> None:
+    g = SurveyGeometry(
+        inline_min=100, inline_max=199, inline_step=1,
+        xline_min=300, xline_max=399, xline_step=1,
+        n_samples=512, sample_rate_ms=4.0,
+    )
+    assert g.n_inlines == 100
+    assert g.n_xlines == 100
+    assert g.shape == (100, 100, 512)
+    assert g.time_max_ms == 511 * 4.0
+
+
+def test_geometry_with_step() -> None:
+    g = SurveyGeometry(
+        inline_min=100, inline_max=200, inline_step=2,
+        xline_min=300, xline_max=320, xline_step=4,
+        n_samples=10, sample_rate_ms=2.0,
+    )
+    assert g.n_inlines == 51
+    assert g.n_xlines == 6
+    assert g.shape == (51, 6, 10)
+
+
+def test_geometry_is_frozen() -> None:
+    g = SurveyGeometry(
+        inline_min=0, inline_max=9, inline_step=1,
+        xline_min=0, xline_max=9, xline_step=1,
+        n_samples=10, sample_rate_ms=1.0,
+    )
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        g.inline_min = 999  # type: ignore[misc]
+
+
+def test_fake_backend_satisfies_protocol(fake_backend) -> None:
+    assert isinstance(fake_backend, SeismicBackend)
+
+
+def test_volume_delegates_to_backend(fake_backend) -> None:
+    vol = SeismicVolume(fake_backend, name="test")
+    assert vol.name == "test"
+    assert vol.shape == fake_backend.geometry.shape
+    assert vol.dtype == np.dtype(np.float32)
+    assert vol.geometry == fake_backend.geometry
+    g = vol.geometry
+    eq = np.testing.assert_array_equal
+    eq(vol.read_inline(g.inline_min), fake_backend.read_inline(g.inline_min))
+    eq(vol.read_xline(g.xline_min), fake_backend.read_xline(g.xline_min))
+    eq(vol.read_timeslice(0), fake_backend.read_timeslice(0))
+    il, xl = g.inline_min, g.xline_min
+    eq(vol.read_trace(il, xl), fake_backend.read_trace(il, xl))
+
+
+def test_volume_repr(fake_backend) -> None:
+    vol = SeismicVolume(fake_backend, name="f3")
+    text = repr(vol)
+    assert "f3" in text
+    assert "SeismicVolume" in text

--- a/tests/test_mdio_backend.py
+++ b/tests/test_mdio_backend.py
@@ -1,0 +1,67 @@
+"""Integration tests for MDIOBackend against a real MDIO survey.
+
+These tests require EGGSEIS_TEST_MDIO to point at an MDIO v1 dataset.
+Otherwise they skip — they're not run in the default CI matrix until a
+fixture survey is wired up.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+mdio = pytest.importorskip("mdio")
+from eggseis.backends.mdio import MDIOBackend  # noqa: E402
+from eggseis.data import SeismicBackend, SeismicVolume  # noqa: E402
+
+
+def test_backend_satisfies_protocol(sample_mdio_path) -> None:
+    backend = MDIOBackend(sample_mdio_path)
+    assert isinstance(backend, SeismicBackend)
+
+
+def test_geometry_is_consistent(sample_mdio_path) -> None:
+    backend = MDIOBackend(sample_mdio_path)
+    g = backend.geometry
+    assert g.n_inlines > 0
+    assert g.n_xlines > 0
+    assert g.n_samples > 0
+    assert g.shape == (g.n_inlines, g.n_xlines, g.n_samples)
+
+
+def test_read_inline_shape(sample_mdio_path) -> None:
+    backend = MDIOBackend(sample_mdio_path)
+    g = backend.geometry
+    arr = backend.read_inline(g.inline_min)
+    assert arr.shape == (g.n_xlines, g.n_samples)
+    assert np.issubdtype(arr.dtype, np.floating)
+
+
+def test_read_xline_shape(sample_mdio_path) -> None:
+    backend = MDIOBackend(sample_mdio_path)
+    g = backend.geometry
+    arr = backend.read_xline(g.xline_min)
+    assert arr.shape == (g.n_inlines, g.n_samples)
+
+
+def test_read_timeslice_shape(sample_mdio_path) -> None:
+    backend = MDIOBackend(sample_mdio_path)
+    g = backend.geometry
+    arr = backend.read_timeslice(0)
+    assert arr.shape == (g.n_inlines, g.n_xlines)
+
+
+def test_read_trace_shape(sample_mdio_path) -> None:
+    backend = MDIOBackend(sample_mdio_path)
+    g = backend.geometry
+    arr = backend.read_trace(g.inline_min, g.xline_min)
+    assert arr.shape == (g.n_samples,)
+
+
+def test_volume_wraps_backend(sample_mdio_path) -> None:
+    backend = MDIOBackend(sample_mdio_path)
+    vol = SeismicVolume(backend, name="fixture")
+    assert vol.name == "fixture"
+    g = vol.geometry
+    arr = vol.read_inline(g.inline_min)
+    assert arr.shape == (g.n_xlines, g.n_samples)


### PR DESCRIPTION
Closes #1

## Summary

- `SeismicVolume` / `SurveyGeometry` / `SeismicBackend` Protocol — the stable public data abstraction
- `MDIOBackend` reads MDIO v1 surveys via `mdio.open_mdio` (xarray-backed, lazy slicing through Zarr)
- Typer CLI: `eggseis info <survey>`, `eggseis dump-inline <survey> <inline> -o <png>`
- Pytest suite (13 tests) with a session-scoped synthetic MDIO fixture built via `mdio.to_mdio`
- CI matrix: ubuntu / macos / windows × Python 3.10 / 3.11 / 3.12, ruff + pytest

Adds `ROADMAP.md` and `M1-PLAN.md` as the working planning docs (referenced from `README.md`).

## Plan deviations

The plan referenced an old MDIO 0.x API (`MDIOReader`) — verified against live `mdio-python` and updated:

- PyPI dist is `multidimio` (not `mdio`)
- v1 public API is `open_mdio()` returning an `xarray.Dataset`
- Default 3D-poststack dim names: `(inline, crossline, time|depth)` — backend resolves dim names defensively (also accepts `xline`)

## Test plan

- [ ] CI green on Linux / macOS / Windows × py 3.10 / 3.11 / 3.12
- [x] Local: `pytest` → 13 passed
- [x] Local: `ruff check .` clean
- [x] Local: `eggseis info demo.mdio` prints geometry table
- [x] Local: `eggseis dump-inline demo.mdio 130 -o inline.png` produces a recognizable seismic PNG

## Out of scope (deferred to later milestones per ROADMAP.md)

- SEG-Y import (mdio's own `segy_to_mdio` works directly for now)
- Qt UI / section viewer (M2)
- Plugin API (M3)
- Compute engine, caching, debounce (M4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)